### PR TITLE
Allow the `--yes` parameter to disable the cancel

### DIFF
--- a/src/deadline/client/cli/_groups/bundle_group.py
+++ b/src/deadline/client/cli/_groups/bundle_group.py
@@ -159,7 +159,8 @@ def bundle_submit(
                 )
 
         # Exit early if there are no warnings and we've either set auto accept or there's no files to confirm
-        if not warning_message and (
+        # if not warning_message and (
+        if (
             yes
             or config_file.str2bool(get_setting("settings.auto_accept", config=config))
             or upload_group.total_input_files == 0


### PR DESCRIPTION
This will allow the `--yes` parameter to disable the Y/N prompt from the `_decide_cancel_submission` callback function.

### What was the problem/requirement? (What/Why)

### What was the solution? (How)

### What is the impact of this change?

### How was this change tested?

### Was this change documented?

### Is this a breaking change?

----

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*